### PR TITLE
Make it ES5: replace `let` with `var` so file can be run through uglifyjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ module.exports = function (object) {
   var keys = Object.keys(object);
   var values = [];
 
-  for (let key in object) {
-    let value = object[key];
+  for (var key in object) {
+    var value = object[key];
     values.push(value);
   }
 

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@
 module.exports = function (object) {
   var keys = Object.keys(object);
   var values = [];
+  var key;
 
-  for (var key in object) {
-    var value = object[key];
-    values.push(value);
+  for (key in object) {
+    values.push(object[key]);
   }
 
   return Promise.all(values).then(function (results) {


### PR DESCRIPTION
My build step doesn't currently involve compiling my node_modules, and I'd rather not have to add that. This makes the library ES5.